### PR TITLE
Allow CMake to build `dielib` as static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
 cmake_minimum_required(VERSION 3.10)
+option(DIE_BUILD_AS_STATIC "Build DieLib as a static library (instead of shared)" OFF)
 project(dielib)
 add_subdirectory(src)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -38,10 +38,18 @@ set(PROJECT_SOURCES
         die_lib.cpp
         die_lib.h
 )
-    
-add_library(die SHARED
-    ${PROJECT_SOURCES}
-)
+
+if(DIE_BUILD_AS_STATIC)
+    message(STATUS "Building DieLib as static")
+    add_library(die STATIC
+        ${PROJECT_SOURCES}
+    )
+else()
+    message(STATUS "Building DieLib as shared")
+    add_library(die SHARED
+        ${PROJECT_SOURCES}
+    )
+endif()
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 


### PR DESCRIPTION
Currently the `die` project is set to always build as a shared library which limits the integration to other projects.
This PR adds a CMake option `DIE_BUILD_AS_STATIC` (default OFF) to allow such case.