### PR TITLE
Make `die_library` thread-safe

### DIFF
--- a/src/lib/die_lib.cpp
+++ b/src/lib/die_lib.cpp
@@ -32,6 +32,15 @@ static std::shared_ptr<QCoreApplication> pApp = nullptr;
 static std::mutex pApp_mutex;
 }  // namespace QCoreAppDLL
 
+static void StaticDeletePointer(void *p)
+{
+    if (p)
+    {
+        delete p;
+        p = nullptr;
+    }
+}
+
 LIB_SOURCE_EXPORT char *DIE_ScanFileA(char *pszFileName, unsigned int nFlags, char *pszDatabase)
 {
     return DIE_lib().scanFileA(pszFileName, nFlags, pszDatabase);
@@ -110,8 +119,10 @@ DIE_lib::DIE_lib()
     std::lock_guard<std::mutex> scope_guard(QCoreAppDLL::pApp_mutex);
     if (!QCoreAppDLL::pApp)
     {
-        QCoreAppDLL::pApp = std::make_shared<QCoreApplication>(QCoreAppDLL::argc, QCoreAppDLL::argv);
+        QCoreAppDLL::pApp = std::shared_ptr<QCoreApplication>(new QCoreApplication(QCoreAppDLL::argc, QCoreAppDLL::argv), StaticDeletePointer);
     }
+
+    m_App = QCoreAppDLL::pApp;
 
     if (!g_pDieScript) {
         g_pDieScript = new DiE_Script;

--- a/src/lib/die_lib.h
+++ b/src/lib/die_lib.h
@@ -64,6 +64,7 @@ private:
 
 private:
     static DiE_Script *g_pDieScript;
+    std::shared_ptr<QApplication> m_App;
 };
 
 #endif  // DIE_LIB_H

--- a/src/lib/die_lib.h
+++ b/src/lib/die_lib.h
@@ -64,7 +64,7 @@ private:
 
 private:
     static DiE_Script *g_pDieScript;
-    std::shared_ptr<QApplication> m_App;
+    std::shared_ptr<QCoreApplication> m_App;
 };
 
 #endif  // DIE_LIB_H


### PR DESCRIPTION
# Description

In its current form, `die_library::DIE_lib` is not thread-safe, the result is that many threads could access concurrently any of the C++ API functions (`DIE_ScanFileA`, ...) simultaneously and since `QCoreApplication` will `assert` on multiple instances being created, this leads to a program crash, with a message as follow:

![{806B2913-12BC-49A3-A373-5668277CD715}](https://github.com/user-attachments/assets/61469932-1b9b-476a-90b0-15e071d3bf6e)

This PR fixes the behavior by adding a `std::mutex` on object initialization, ensuring no more than one thread can create `QCoreApplication` if it's not already existing. In addition the static raw pointer to `QCoreApplication` named `pApp` is now a `std::shared_ptr<QCoreApplication>` to ensure no more than 1 instance exists, and is correctly deleted when the last `DIE_lib()` is destroyed.