### PR TITLE
Ensure `-fPIC` flag is passed for Linux/macOS builds

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -19,6 +19,8 @@ if(WIN32)
         set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zc:wchar_t-")
         set (CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /Zc:wchar_t-")
     endif()
+else()
+    add_definitions(-fPIC)
 endif()
 
 add_definitions(
@@ -28,8 +30,7 @@ add_definitions(
     -DUSE_PDF
     -DUSE_ARCHIVE
     -DUSE_YARA
-    -fPIC
-    )
+)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../dep/die_script/die_script.cmake)
 include(GNUInstallDirs)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ add_definitions(
     -DUSE_PDF
     -DUSE_ARCHIVE
     -DUSE_YARA
+    -fPIC
     )
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../dep/die_script/die_script.cmake)


### PR DESCRIPTION
## Description

While working on ARM64 build for DIE-Python (elastic/die-python#29), I noticed `-fPIC` is not explicitly set for `die_library` resulting in several linkage errors with gcc - this behavior was only observed with arm64 though , not x86/64 🤔.

This PR fixes this behavior by ensuring Linux & macOS builds are passed the `-fPIC` flag to generate position independent code for the library.