### PR TITLE
Fix typo in exported DIE_LoadDatabase function names

### DIFF
--- a/src/include/die.def
+++ b/src/include/die.def
@@ -1,8 +1,8 @@
 LIBRARY die.dll
 
 EXPORTS
-DIE_LoadDatebaseA
-DIE_LoadDatebaseW
+DIE_LoadDatabaseA
+DIE_LoadDatabaseW
 DIE_FreeMemoryA
 DIE_FreeMemoryW
 DIE_ScanFileA
@@ -14,3 +14,4 @@ DIE_ScanFileExW
 DIE_ScanMemoryExA
 DIE_ScanMemoryExW
 DIE_VB_ScanFile
+DIE_VB_ScanFileCallback


### PR DESCRIPTION
The exported names in die.def used "Datebase" instead of "Database". This makes the exported symbols inconsistent with die.h and die_lib.cpp.

Fix the spelling and keep backward compatibility aliases.